### PR TITLE
Vberenz/sim real config

### DIFF
--- a/demos/demo_dummy.cpp
+++ b/demos/demo_dummy.cpp
@@ -5,7 +5,8 @@
 void run()
 {
     // configuration for this robot instance
-    pam_interface::Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = true;
+    pam_interface::Pamy1DefaultConfiguration<4> configuration(simulation);
 
     pam_interface::DummyRobotDriver<4> robot(configuration);
 

--- a/demos/demo_real.cpp
+++ b/demos/demo_real.cpp
@@ -5,7 +5,8 @@
 void run()
 {
     // configuration for this robot instance
-    pam_interface::Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = false;
+    pam_interface::Pamy1DefaultConfiguration<4> configuration(simulation);
 
     pam_interface::Pamy1Driver<4> robot(configuration);
 

--- a/demos/pamy2_udp_communication.cpp
+++ b/demos/pamy2_udp_communication.cpp
@@ -52,7 +52,8 @@ static void perform_steps(pam_interface::UDPCommunication udp_com)
 
 void perform(std::string ip, uint port)
 {
-    pam_interface::Pamy2DefaultConfiguration config;
+    bool simulation = false;
+    pam_interface::Pamy2DefaultConfiguration config(simulation);
     pam_interface::UDPCommunication udp_com(config, ip, port);
     perform_steps(udp_com);
 }

--- a/include/pam_interface/real/pamy1/configuration.hpp
+++ b/include/pam_interface/real/pamy1/configuration.hpp
@@ -5,7 +5,8 @@
 
 // parent folder will be ~/.mpi-is/pam
 // or /opt/mpi-is/pam
-#define PAMY1_JSON_RELATIVE_PATH "pam_interface/pamy1/config/pam.json"
+#define PAMY1_REAL_JSON_RELATIVE_PATH "pam_interface/pamy1/config/pam.json"
+#define PAMY1_SIM_JSON_RELATIVE_PATH "pam_interface/pamy1/config/pam_sim.json"
 
 namespace pam_interface
 {
@@ -13,8 +14,8 @@ template <int NB_DOFS>
 class Pamy1DefaultConfiguration : public JsonConfiguration<NB_DOFS>
 {
 public:
-    Pamy1DefaultConfiguration();
-    static std::string get_default_configuration_path();
+    Pamy1DefaultConfiguration(bool simulation);
+    static std::string get_default_configuration_path(bool simulation);
 };
 
 #include "configuration.hxx"

--- a/include/pam_interface/real/pamy1/configuration.hxx
+++ b/include/pam_interface/real/pamy1/configuration.hxx
@@ -1,12 +1,19 @@
 
 template <int NB_DOFS>
-Pamy1DefaultConfiguration<NB_DOFS>::Pamy1DefaultConfiguration()
-    : JsonConfiguration<NB_DOFS>(get_default_configuration_path())
+Pamy1DefaultConfiguration<NB_DOFS>::Pamy1DefaultConfiguration(bool simulation)
+    : JsonConfiguration<NB_DOFS>(get_default_configuration_path(simulation))
 {
 }
 
 template <int NB_DOFS>
-std::string Pamy1DefaultConfiguration<NB_DOFS>::get_default_configuration_path()
+std::string Pamy1DefaultConfiguration<NB_DOFS>::get_default_configuration_path(bool simulation)
 {
-  return ( pam_configuration::get_path() / std::string(PAMY1_JSON_RELATIVE_PATH) ).string();
+  if (simulation)
+    {
+      return ( pam_configuration::get_path() / std::string(PAMY1_SIM_JSON_RELATIVE_PATH) ).string();
+    }
+  else
+    {
+      return ( pam_configuration::get_path() / std::string(PAMY1_REAL_JSON_RELATIVE_PATH) ).string();
+    }
 }

--- a/include/pam_interface/real/pamy2/configuration.hpp
+++ b/include/pam_interface/real/pamy2/configuration.hpp
@@ -5,15 +5,17 @@
 
 // parent folder will be ~/.mpi-is/pam
 // or /opt/mpi-is/pam
-#define PAMY2_JSON_RELATIVE_PATH "pam_interface/pamy2/config/pam.json"
+// (same file for simulation and real robot)
+#define PAMY2_REAL_JSON_RELATIVE_PATH "pam_interface/pamy2/config/pam.json"
+#define PAMY2_SIM_JSON_RELATIVE_PATH "pam_interface/pamy2/config/pam.json"
 
 namespace pam_interface
 {
 class Pamy2DefaultConfiguration : public JsonConfiguration<4>
 {
 public:
-    Pamy2DefaultConfiguration();
-    static std::string get_default_configuration_path();
+    Pamy2DefaultConfiguration(bool simulation);
+    static std::string get_default_configuration_path(bool simulation);
 };
 
 }  // namespace pam_interface

--- a/src/pamy2_configuration.cpp
+++ b/src/pamy2_configuration.cpp
@@ -2,14 +2,22 @@
 
 namespace pam_interface
 {
-Pamy2DefaultConfiguration::Pamy2DefaultConfiguration()
-  : JsonConfiguration<4>(get_default_configuration_path())
+Pamy2DefaultConfiguration::Pamy2DefaultConfiguration(bool simulation)
+  : JsonConfiguration<4>(get_default_configuration_path(simulation))
 {
 }
 
-std::string Pamy2DefaultConfiguration::get_default_configuration_path()
+std::string Pamy2DefaultConfiguration::get_default_configuration_path(bool simulation)
 {
-  return ( pam_configuration::get_path() / std::string(PAMY2_JSON_RELATIVE_PATH) ).string();
+  if(simulation)
+    {
+      return ( pam_configuration::get_path() / std::string(PAMY2_SIM_JSON_RELATIVE_PATH) ).string();
+    }
+  else
+    {
+      return ( pam_configuration::get_path() / std::string(PAMY2_REAL_JSON_RELATIVE_PATH) ).string();
+    }
+
 }
 
 }  // namespace pam_interface

--- a/srcpy/wrappers.cpp
+++ b/srcpy/wrappers.cpp
@@ -48,13 +48,13 @@ PYBIND11_MODULE(pam_interface, m)
 
     pybind11::class_<Pamy1DefaultConfig, JsonConfig>(
         m, "Pamy1DefaultConfiguration")
-        .def(pybind11::init<>())
+        .def(pybind11::init<bool>())
         .def("display", &Pamy1DefaultConfig::print)
         .def("get_path", &Pamy1DefaultConfig::get_default_configuration_path);
 
     pybind11::class_<Pamy2DefaultConfig, JsonConfig>(
         m, "Pamy2DefaultConfiguration")
-        .def(pybind11::init<>())
+        .def(pybind11::init<bool>())
         .def("display", &Pamy2DefaultConfig::print)
         .def("get_path", &Pamy2DefaultConfig::get_default_configuration_path);
 
@@ -151,4 +151,5 @@ PYBIND11_MODULE(pam_interface, m)
         .def(pybind11::init<const Config>())
         .def("pressure_in", &DummyDriver::in)
         .def("data_out", &DummyDriver::out);
+
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -27,7 +27,8 @@ class PamInterfaceTests : public ::testing::Test
 
 TEST_F(PamInterfaceTests, dummy_interface)
 {
-    Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = true;
+    Pamy1DefaultConfiguration<4> configuration(simulation);
     DummyInterface<4> interface(configuration);
     interface.set_pressure(1, Sign::AGONIST, 16000);
     interface.set_pressure(2, Sign::ANTAGONIST, 16500);
@@ -37,19 +38,22 @@ TEST_F(PamInterfaceTests, dummy_interface)
 
 TEST_F(PamInterfaceTests, pamy1_interface_instantiation)
 {
-    Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = true;
+    Pamy1DefaultConfiguration<4> configuration(simulation);
     Pamy1Interface<4> interface(configuration);
 }
 
 TEST_F(PamInterfaceTests, dummy_driver_instantiation)
 {
-    Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = true;
+    Pamy1DefaultConfiguration<4> configuration(simulation);
     DummyRobotDriver<4> driver(configuration);
 }
 
 TEST_F(PamInterfaceTests, dummy_robot)
 {
-    Pamy1DefaultConfiguration<4> configuration;
+    bool simulation = true;
+    Pamy1DefaultConfiguration<4> configuration(simulation);
 
     pam_interface::DummyRobotDriver<4> robot(configuration);
 
@@ -100,26 +104,24 @@ TEST_F(PamInterfaceTests, rotate)
     ASSERT_NEAR(angle, -pi / 8., precision);
 }
 
-
 static void test_config(const pam_interface::Configuration<NB_DOFS>& config)
 {
-  for(int dof=0;dof<NB_DOFS;dof++)
+    for (int dof = 0; dof < NB_DOFS; dof++)
     {
-      ASSERT_GT(config.max_pressures_ago[dof],
-		config.min_pressures_ago[dof]);
+        ASSERT_GT(config.max_pressures_ago[dof], config.min_pressures_ago[dof]);
     }
-
 }
-
 
 TEST_F(PamInterfaceTests, pamy1_configuration)
 {
-  Pamy1DefaultConfiguration<4> configuration;
-  test_config(configuration);
+    bool simulation = true;
+    Pamy1DefaultConfiguration<4> configuration(simulation);
+    test_config(configuration);
 }
 
 TEST_F(PamInterfaceTests, pamy2_configuration)
 {
-  Pamy2DefaultConfiguration configuration;
-  test_config(configuration);
+    bool simulation = true;
+    Pamy2DefaultConfiguration configuration(simulation);
+    test_config(configuration);
 }


### PR DESCRIPTION
…or simulation

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

For pamy1, the default configuration file is not the same if running the real robot or the simulated robot.
Added a bool argument to the get_path method so that the suitable default path is returned.

## How I Tested

Ran the demos

