### PR TITLE
set_joint method added to RobotState wrappers

### DIFF
--- a/srcpy/wrappers.cpp
+++ b/srcpy/wrappers.cpp
@@ -60,6 +60,7 @@ PYBIND11_MODULE(pam_interface, m)
 
     pybind11::class_<RobotState>(m, "RobotState")
         .def(pybind11::init<>())
+        .def("set_joint", &RobotState::set_joint)
         .def("get_id", &RobotState::get_id)
         .def("get_desired", &RobotState::get_desired)
         .def("get", &RobotState::get)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Added the method 'set_joint' to the python wrappers of the RobotState class

## How I Tested

Using this function in the unit tests of o80_pam

